### PR TITLE
Symbolic links to ease ArduinoIDE compilation

### DIFF
--- a/firmware/releases/ips2_damper/auto_mute.cpp
+++ b/firmware/releases/ips2_damper/auto_mute.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/auto_mute.cpp

--- a/firmware/releases/ips2_damper/auto_mute.h
+++ b/firmware/releases/ips2_damper/auto_mute.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/auto_mute.h

--- a/firmware/releases/ips2_damper/board2board.cpp
+++ b/firmware/releases/ips2_damper/board2board.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/board2board.cpp

--- a/firmware/releases/ips2_damper/board2board.h
+++ b/firmware/releases/ips2_damper/board2board.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/board2board.h

--- a/firmware/releases/ips2_damper/calibration_position.cpp
+++ b/firmware/releases/ips2_damper/calibration_position.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_position.cpp

--- a/firmware/releases/ips2_damper/calibration_position.h
+++ b/firmware/releases/ips2_damper/calibration_position.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_position.h

--- a/firmware/releases/ips2_damper/calibration_velocity.cpp
+++ b/firmware/releases/ips2_damper/calibration_velocity.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_velocity.cpp

--- a/firmware/releases/ips2_damper/calibration_velocity.h
+++ b/firmware/releases/ips2_damper/calibration_velocity.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_velocity.h

--- a/firmware/releases/ips2_damper/dsp_damper.cpp
+++ b/firmware/releases/ips2_damper/dsp_damper.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_damper.cpp

--- a/firmware/releases/ips2_damper/dsp_damper.h
+++ b/firmware/releases/ips2_damper/dsp_damper.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_damper.h

--- a/firmware/releases/ips2_damper/dsp_hammer.cpp
+++ b/firmware/releases/ips2_damper/dsp_hammer.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_hammer.cpp

--- a/firmware/releases/ips2_damper/dsp_hammer.h
+++ b/firmware/releases/ips2_damper/dsp_hammer.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_hammer.h

--- a/firmware/releases/ips2_damper/dsp_pedal.cpp
+++ b/firmware/releases/ips2_damper/dsp_pedal.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_pedal.cpp

--- a/firmware/releases/ips2_damper/dsp_pedal.h
+++ b/firmware/releases/ips2_damper/dsp_pedal.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_pedal.h

--- a/firmware/releases/ips2_damper/midiout.cpp
+++ b/firmware/releases/ips2_damper/midiout.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/midiout.cpp

--- a/firmware/releases/ips2_damper/midiout.h
+++ b/firmware/releases/ips2_damper/midiout.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/midiout.h

--- a/firmware/releases/ips2_damper/network.cpp
+++ b/firmware/releases/ips2_damper/network.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/network.cpp

--- a/firmware/releases/ips2_damper/network.h
+++ b/firmware/releases/ips2_damper/network.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/network.h

--- a/firmware/releases/ips2_damper/nonvolatile.cpp
+++ b/firmware/releases/ips2_damper/nonvolatile.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/nonvolatile.cpp

--- a/firmware/releases/ips2_damper/nonvolatile.h
+++ b/firmware/releases/ips2_damper/nonvolatile.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/nonvolatile.h

--- a/firmware/releases/ips2_damper/six_channel_analog_00.cpp
+++ b/firmware/releases/ips2_damper/six_channel_analog_00.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/six_channel_analog_00.cpp

--- a/firmware/releases/ips2_damper/six_channel_analog_00.h
+++ b/firmware/releases/ips2_damper/six_channel_analog_00.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/six_channel_analog_00.h

--- a/firmware/releases/ips2_damper/stem_piano_ips2.h
+++ b/firmware/releases/ips2_damper/stem_piano_ips2.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/stem_piano_ips2.h

--- a/firmware/releases/ips2_damper/switches.cpp
+++ b/firmware/releases/ips2_damper/switches.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/switches.cpp

--- a/firmware/releases/ips2_damper/switches.h
+++ b/firmware/releases/ips2_damper/switches.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/switches.h

--- a/firmware/releases/ips2_damper/testpoint_led.cpp
+++ b/firmware/releases/ips2_damper/testpoint_led.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/testpoint_led.cpp

--- a/firmware/releases/ips2_damper/testpoint_led.h
+++ b/firmware/releases/ips2_damper/testpoint_led.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/testpoint_led.h

--- a/firmware/releases/ips2_damper/tft_display.cpp
+++ b/firmware/releases/ips2_damper/tft_display.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_display.cpp

--- a/firmware/releases/ips2_damper/tft_display.h
+++ b/firmware/releases/ips2_damper/tft_display.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_display.h

--- a/firmware/releases/ips2_damper/tft_text.cpp
+++ b/firmware/releases/ips2_damper/tft_text.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_text.cpp

--- a/firmware/releases/ips2_damper/tft_text.h
+++ b/firmware/releases/ips2_damper/tft_text.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_text.h

--- a/firmware/releases/ips2_damper/timing.cpp
+++ b/firmware/releases/ips2_damper/timing.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/timing.cpp

--- a/firmware/releases/ips2_damper/timing.h
+++ b/firmware/releases/ips2_damper/timing.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/timing.h

--- a/firmware/releases/ips2_damper/utilities.cpp
+++ b/firmware/releases/ips2_damper/utilities.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/utilities.cpp

--- a/firmware/releases/ips2_damper/utilities.h
+++ b/firmware/releases/ips2_damper/utilities.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/utilities.h

--- a/firmware/releases/ips2_hammer/auto_mute.cpp
+++ b/firmware/releases/ips2_hammer/auto_mute.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/auto_mute.cpp

--- a/firmware/releases/ips2_hammer/auto_mute.h
+++ b/firmware/releases/ips2_hammer/auto_mute.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/auto_mute.h

--- a/firmware/releases/ips2_hammer/board2board.cpp
+++ b/firmware/releases/ips2_hammer/board2board.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/board2board.cpp

--- a/firmware/releases/ips2_hammer/board2board.h
+++ b/firmware/releases/ips2_hammer/board2board.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/board2board.h

--- a/firmware/releases/ips2_hammer/calibration_position.cpp
+++ b/firmware/releases/ips2_hammer/calibration_position.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_position.cpp

--- a/firmware/releases/ips2_hammer/calibration_position.h
+++ b/firmware/releases/ips2_hammer/calibration_position.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_position.h

--- a/firmware/releases/ips2_hammer/calibration_velocity.cpp
+++ b/firmware/releases/ips2_hammer/calibration_velocity.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_velocity.cpp

--- a/firmware/releases/ips2_hammer/calibration_velocity.h
+++ b/firmware/releases/ips2_hammer/calibration_velocity.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/calibration_velocity.h

--- a/firmware/releases/ips2_hammer/dsp_damper.cpp
+++ b/firmware/releases/ips2_hammer/dsp_damper.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_damper.cpp

--- a/firmware/releases/ips2_hammer/dsp_damper.h
+++ b/firmware/releases/ips2_hammer/dsp_damper.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_damper.h

--- a/firmware/releases/ips2_hammer/dsp_hammer.cpp
+++ b/firmware/releases/ips2_hammer/dsp_hammer.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_hammer.cpp

--- a/firmware/releases/ips2_hammer/dsp_hammer.h
+++ b/firmware/releases/ips2_hammer/dsp_hammer.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_hammer.h

--- a/firmware/releases/ips2_hammer/dsp_pedal.cpp
+++ b/firmware/releases/ips2_hammer/dsp_pedal.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_pedal.cpp

--- a/firmware/releases/ips2_hammer/dsp_pedal.h
+++ b/firmware/releases/ips2_hammer/dsp_pedal.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/dsp_pedal.h

--- a/firmware/releases/ips2_hammer/midiout.cpp
+++ b/firmware/releases/ips2_hammer/midiout.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/midiout.cpp

--- a/firmware/releases/ips2_hammer/midiout.h
+++ b/firmware/releases/ips2_hammer/midiout.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/midiout.h

--- a/firmware/releases/ips2_hammer/network.cpp
+++ b/firmware/releases/ips2_hammer/network.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/network.cpp

--- a/firmware/releases/ips2_hammer/network.h
+++ b/firmware/releases/ips2_hammer/network.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/network.h

--- a/firmware/releases/ips2_hammer/nonvolatile.cpp
+++ b/firmware/releases/ips2_hammer/nonvolatile.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/nonvolatile.cpp

--- a/firmware/releases/ips2_hammer/nonvolatile.h
+++ b/firmware/releases/ips2_hammer/nonvolatile.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/nonvolatile.h

--- a/firmware/releases/ips2_hammer/six_channel_analog_00.cpp
+++ b/firmware/releases/ips2_hammer/six_channel_analog_00.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/six_channel_analog_00.cpp

--- a/firmware/releases/ips2_hammer/six_channel_analog_00.h
+++ b/firmware/releases/ips2_hammer/six_channel_analog_00.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/six_channel_analog_00.h

--- a/firmware/releases/ips2_hammer/stem_piano_ips2.h
+++ b/firmware/releases/ips2_hammer/stem_piano_ips2.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/stem_piano_ips2.h

--- a/firmware/releases/ips2_hammer/switches.cpp
+++ b/firmware/releases/ips2_hammer/switches.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/switches.cpp

--- a/firmware/releases/ips2_hammer/switches.h
+++ b/firmware/releases/ips2_hammer/switches.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/switches.h

--- a/firmware/releases/ips2_hammer/testpoint_led.cpp
+++ b/firmware/releases/ips2_hammer/testpoint_led.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/testpoint_led.cpp

--- a/firmware/releases/ips2_hammer/testpoint_led.h
+++ b/firmware/releases/ips2_hammer/testpoint_led.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/testpoint_led.h

--- a/firmware/releases/ips2_hammer/tft_display.cpp
+++ b/firmware/releases/ips2_hammer/tft_display.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_display.cpp

--- a/firmware/releases/ips2_hammer/tft_display.h
+++ b/firmware/releases/ips2_hammer/tft_display.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_display.h

--- a/firmware/releases/ips2_hammer/tft_text.cpp
+++ b/firmware/releases/ips2_hammer/tft_text.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_text.cpp

--- a/firmware/releases/ips2_hammer/tft_text.h
+++ b/firmware/releases/ips2_hammer/tft_text.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/tft_text.h

--- a/firmware/releases/ips2_hammer/timing.cpp
+++ b/firmware/releases/ips2_hammer/timing.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/timing.cpp

--- a/firmware/releases/ips2_hammer/timing.h
+++ b/firmware/releases/ips2_hammer/timing.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/timing.h

--- a/firmware/releases/ips2_hammer/utilities.cpp
+++ b/firmware/releases/ips2_hammer/utilities.cpp
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/utilities.cpp

--- a/firmware/releases/ips2_hammer/utilities.h
+++ b/firmware/releases/ips2_hammer/utilities.h
@@ -1,0 +1,1 @@
+../StemPianoIPS2/src/utilities.h


### PR DESCRIPTION
Another small thing to simplify the setup to compile in ArduinoIDE for newcomers. 

Idea: make the sketches (both for hammer and dampers) self-sufficient, without the need to configure `StemPianoIPS2` as a library, and without duplicating the files (in fact the "added" things are just symbolic links to the original ones, which remain in their initial location).

**IMPORTANT:**
This works great in Linux (fully tested) and I am confident it works in MacOS too (not fully tested though). However I cannot test it in Windows, and it will be important to test it there, since I suppose many people will use git and ArduinoIDE there. So if it works there, this will be a great thing to merge, but if Windows has trouble with symbolic links (either because git creates duplicate files rather than links, or because ArduinoIDE in Windows does not recognize the target files correctly), then it would be better to drop this PR rather than merge it.