### PR TITLE
option to change parameters live

### DIFF
--- a/firmware/releases/ips2_damper/ips2_damper.ino
+++ b/firmware/releases/ips2_damper/ips2_damper.ino
@@ -136,6 +136,7 @@ void partial_setup(void) {
   delay(1000);
   Tft.Clear();
 
+  Serial.println("Press 1 to enter parameter edit mode.");
 }
 
 // After startup, wait before sending anything to MIDI
@@ -249,6 +250,13 @@ void edit_parameters() {
 }
 
 void loop() {
+
+  if (Serial.available() > 0) {
+    input_field = Serial.parseInt(); // defaults to zero if times out
+    if (input_field == 1) {
+      edit_parameters();
+    }
+  }
 
   Tmg.WarnOnProcessingInterval();
   DStat.DisplayProcessingIntervalStart();

--- a/firmware/releases/ips2_damper/ips2_damper.ino
+++ b/firmware/releases/ips2_damper/ips2_damper.ino
@@ -57,7 +57,13 @@ Timing Tmg;
 TftDisplay Tft;
 
 void setup(void) {
+  // Load the settings. Must be first in the setup() function.
+  Set.SetAllSettingValues();
 
+  partial_setup();
+}
+
+void partial_setup(void) {
   // Serial port setup.
   Serial.begin(9600);
   Serial.println(".");
@@ -77,9 +83,6 @@ void setup(void) {
   Serial.println("https://github.com/stem-piano");
   Serial.println(".");
   Serial.println(".");
-
-  // Load the settings. Must be first in the setup() function.
-  Set.SetAllSettingValues();
 
   // Notification messages.
   if (Set.debug_level >= DEBUG_INFO) {
@@ -160,6 +163,90 @@ position_floats[NUM_CHANNELS];
 float damper_threshold_low = 0.33;
 float damper_threshold_med = 0.50;
 float damper_threshold_high = 0.75;
+
+int input_field = -1;
+bool keep_editing = false;
+
+void edit_parameters() {
+  // effectively "infinite" timeout (~ 1 month) when waiting for input
+  // in this function (parameter editing mode)
+  Serial.setTimeout(2073600000L);
+
+  Serial.println("Entered parameter editing mode.");
+  keep_editing = true;
+  while (keep_editing) {
+    Serial.println("Which parameter would you like to edit?");
+    Serial.println("0. NONE, done editing, resume normal operations");
+    Serial.println("1. debug_level");
+    Serial.println("2. sensor_v_max");
+    Serial.println("3. adc_reference");
+    Serial.println("4. adc_global_scale");
+    Serial.println("5. N/A");
+    Serial.println("6. calibration_threshold");
+
+    if (Serial.available() > 0) {
+      input_field = Serial.parseInt();
+      switch (input_field) {
+        case 0:
+           // taken care of later
+          break;
+        case 1:
+          // debug_level is INTEGER!
+          Serial.print("Enter debug_level, currently ");
+          Serial.println(Set.debug_level);
+          Set.debug_level = Serial.parseInt();
+          Serial.print("Set debug_level = ");
+          Serial.println(Set.debug_level);
+          break;
+        case 2:
+          Serial.print("Enter sensor_v_max, currently ");
+          Serial.println(Set.sensor_v_max);
+          Set.sensor_v_max = Serial.parseFloat();
+          Serial.print("Set sensor_v_max = ");
+          Serial.println(Set.sensor_v_max);
+          break;
+        case 3:
+          Serial.print("Enter adc_reference, currently ");
+          Serial.println(Set.adc_reference);
+          Set.adc_reference = Serial.parseFloat();
+          Serial.print("Set adc_reference = ");
+          Serial.println(Set.adc_reference);
+          break;
+        case 4:
+          Serial.print("Enter adc_global_scale, currently ");
+          Serial.println(Set.adc_global_scale);
+          Set.adc_global_scale = Serial.parseFloat();
+          Serial.print("Set adc_global_scale = ");
+          Serial.println(Set.adc_global_scale);
+          break;
+        case 6:
+          Serial.print("Enter calibration_threshold, currently ");
+          Serial.println(Set.calibration_threshold);
+          Set.calibration_threshold = Serial.parseFloat();
+          Serial.print("Set calibration_threshold = ");
+          Serial.println(Set.calibration_threshold);
+          break;
+
+        default:
+          Serial.print("Case ");
+          Serial.print(input_field);
+          Serial.println(" not supported");
+          break;
+      }
+      if (input_field == 0) {
+        keep_editing = false;
+      }
+    }
+    delay(100);
+  }
+
+  // restore default timeout outside of parameter editing mode
+  Serial.setTimeout(1000L);
+
+  // re-run the set up with the changed values (may be unnecessary)
+  Serial.println("Setting up the board with your changes");
+  partial_setup();
+}
 
 void loop() {
 

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -212,7 +212,23 @@ void edit_parameters() {
   while (keep_editing) {
     Serial.println("Which parameter would you like to edit?");
     Serial.println("0. NONE, done editing, resume normal operations");
-    Serial.println("1. damper_threshold");
+    Serial.println("1. debug_level");
+    Serial.println("2. sensor_v_max");
+    Serial.println("3. adc_reference");
+    Serial.println("4. adc_global_scale");
+    Serial.println("5. velocity_scale");
+    Serial.println("6. calibration_threshold");
+    Serial.println("7. damper_threshold");
+    Serial.println("8. damper_velocity_scaling");
+    Serial.println("9. hammer_strike_algorithm");
+    Serial.println("10. strike_threshold");
+    Serial.println("11. release_threshold");
+    Serial.println("12. min_repetition_seconds");
+    Serial.println("13. min_strike_velocity");
+    Serial.println("14. hammer_travel_meters");
+    Serial.println("15. pedal_threshold");
+    Serial.println("16. canbus_enable");
+
     if (Serial.available() > 0) {
       input_field = Serial.parseInt();
       switch (input_field) {
@@ -220,12 +236,121 @@ void edit_parameters() {
            // taken care of later
           break;
         case 1:
+          // debug_level is INTEGER!
+          Serial.print("Enter debug_level, currently ");
+          Serial.println(Set.debug_level);
+          Set.debug_level = Serial.parseInt();
+          Serial.print("Set debug_level = ");
+          Serial.println(Set.debug_level);
+          break;
+        case 2:
+          Serial.print("Enter sensor_v_max, currently ");
+          Serial.println(Set.sensor_v_max);
+          Set.sensor_v_max = Serial.parseFloat();
+          Serial.print("Set sensor_v_max = ");
+          Serial.println(Set.sensor_v_max);
+          break;
+        case 3:
+          Serial.print("Enter adc_reference, currently ");
+          Serial.println(Set.adc_reference);
+          Set.adc_reference = Serial.parseFloat();
+          Serial.print("Set adc_reference = ");
+          Serial.println(Set.adc_reference);
+          break;
+        case 4:
+          Serial.print("Enter adc_global_scale, currently ");
+          Serial.println(Set.adc_global_scale);
+          Set.adc_global_scale = Serial.parseFloat();
+          Serial.print("Set adc_global_scale = ");
+          Serial.println(Set.adc_global_scale);
+          break;
+        case 5:
+          Serial.print("Enter velocity_scale, currently ");
+          Serial.println(Set.velocity_scale);
+          Set.velocity_scale = Serial.parseFloat();
+          Serial.print("Set velocity_scale = ");
+          Serial.println(Set.velocity_scale);
+          break;
+        case 6:
+          Serial.print("Enter calibration_threshold, currently ");
+          Serial.println(Set.calibration_threshold);
+          Set.calibration_threshold = Serial.parseFloat();
+          Serial.print("Set calibration_threshold = ");
+          Serial.println(Set.calibration_threshold);
+          break;
+        case 7:
           Serial.print("Enter damper_threshold, currently ");
           Serial.println(Set.damper_threshold);
           Set.damper_threshold = Serial.parseFloat();
           Serial.print("Set damper_threshold = ");
           Serial.println(Set.damper_threshold);
           break;
+        case 8:
+          Serial.print("Enter damper_velocity_scaling, currently ");
+          Serial.println(Set.damper_velocity_scaling);
+          Set.damper_velocity_scaling = Serial.parseFloat();
+          Serial.print("Set damper_velocity_scaling = ");
+          Serial.println(Set.damper_velocity_scaling);
+          break;
+        case 9:
+          // hammer_strike_algorithm is INTEGER!
+          Serial.print("Enter , currently ");
+          Serial.println(Set.);
+          Set. = Serial.parseInt();
+          Serial.print("Set  = ");
+          Serial.println(Set.);
+          break;
+        case 10:
+          Serial.print("Enter strike_threshold, currently ");
+          Serial.println(Set.strike_threshold);
+          Set.strike_threshold = Serial.parseFloat();
+          Serial.print("Set strike_threshold = ");
+          Serial.println(Set.strike_threshold);
+          break;
+        case 11:
+          Serial.print("Enter release_threshold, currently ");
+          Serial.println(Set.release_threshold);
+          Set.release_threshold = Serial.parseFloat();
+          Serial.print("Set release_threshold = ");
+          Serial.println(Set.release_threshold);
+          break;
+        case 12:
+          Serial.print("Enter min_repetition_seconds, currently ");
+          Serial.println(Set.min_repetition_seconds);
+          Set.min_repetition_seconds = Serial.parseFloat();
+          Serial.print("Set min_repetition_seconds = ");
+          Serial.println(Set.min_repetition_seconds);
+          break;
+        case 13:
+          Serial.print("Enter min_strike_velocity, currently ");
+          Serial.println(Set.min_strike_velocity);
+          Set.min_strike_velocity = Serial.parseFloat();
+          Serial.print("Set min_strike_velocity = ");
+          Serial.println(Set.min_strike_velocity);
+          break;
+        case 14:
+          Serial.print("Enter hammer_travel_meters, currently ");
+          Serial.println(Set.hammer_travel_meters);
+          Set.hammer_travel_meters = Serial.parseFloat();
+          Serial.print("Set hammer_travel_meters = ");
+          Serial.println(Set.hammer_travel_meters);
+          break;
+        case 15:
+          Serial.print("Enter pedal_threshold, currently ");
+          Serial.println(Set.pedal_threshold);
+          Set.pedal_threshold = Serial.parseFloat();
+          Serial.print("Set pedal_threshold = ");
+          Serial.println(Set.pedal_threshold);
+          break;
+        case 16:
+          // canbus_enable is INTEGER!
+          Serial.print("Enter canbus_enable, currently ");
+          Serial.println(Set.canbus_enable);
+          Set.canbus_enable = Serial.parseFloat();
+          Serial.print("Set canbus_enable = ");
+          Serial.println(Set.canbus_enable);
+          break;
+
         default:
           Serial.print("Case ");
           Serial.print(input_field);

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -294,11 +294,11 @@ void edit_parameters() {
           break;
         case 9:
           // hammer_strike_algorithm is INTEGER!
-          Serial.print("Enter , currently ");
-          Serial.println(Set.);
-          Set. = Serial.parseInt();
-          Serial.print("Set  = ");
-          Serial.println(Set.);
+          Serial.print("Enter hammer_strike_algorithm, currently ");
+          Serial.println(Set.hammer_strike_algorithm);
+          Set.hammer_strike_algorithm = Serial.parseInt();
+          Serial.print("Set hammer_strike_algorithm = ");
+          Serial.println(Set.hammer_strike_algorithm);
           break;
         case 10:
           Serial.print("Enter strike_threshold, currently ");
@@ -368,7 +368,7 @@ void edit_parameters() {
   Serial.setTimeout(1000L);
 
   // re-run the set up with the changed values (may be unnecessary)
-  Serial.println("Setting up the board with your changes")
+  Serial.println("Setting up the board with your changes");
   partial_setup();
 }
 

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -205,48 +205,48 @@ void edit_parameters() {
   // in this function (parameter editing mode)
 
   Serial.setTimeout(2073600000L);
-      Serial.println("Entered parameter editing mode.");
-      Serial.println("Which parameter would you like to edit?");
-      Serial.println("0. NONE, done editing, resume normal operations");
-      Serial.println("1. damper_threshold");
-      edit_mode = true;
-      while (edit_mode) {
-        if (Serial.available() > 0) {
-          input_field = Serial.parseInt();
-          switch (input_field) {
-            case 0:
-              // taken care of later
-              break;
-            case 1:
-              Serial.print("Enter damper_threshold, currently ");
+  Serial.println("Entered parameter editing mode.");
+  Serial.println("Which parameter would you like to edit?");
+  Serial.println("0. NONE, done editing, resume normal operations");
+  Serial.println("1. damper_threshold");
+  edit_mode = true;
+  while (edit_mode) {
+    if (Serial.available() > 0) {
+      input_field = Serial.parseInt();
+      switch (input_field) {
+        case 0:
+           // taken care of later
+          break;
+        case 1:
+          Serial.print("Enter damper_threshold, currently ");
+          Serial.println(Set.damper_threshold);
+          keep_reading = true;
+          while (keep_reading) {
+            if (Serial.available() > 0) {
+              input_data = Serial.parseFloat();
+              Set.damper_threshold = input_data;
+              Serial.print("Set damper_threshold = ");
               Serial.println(Set.damper_threshold);
-              keep_reading = true;
-              while (keep_reading) {
-                if (Serial.available() > 0) {
-                  input_data = Serial.parseFloat();
-                  Set.damper_threshold = input_data;
-                  Serial.print("Set damper_threshold = ");
-                  Serial.println(Set.damper_threshold);
-                  keep_reading = false;
-                }
-                delay(50);
-              }
-              break;
-            default:
-              Serial.print("Case ");
-              Serial.print(input_field);
-              Serial.println(" not supported");
-              Serial.println("Which parameter would you like to edit?");
-              Serial.println("0. NONE, done editing, resume normal operations");
-              Serial.println("1. damper_threshold");
-              break;
+              keep_reading = false;
+            }
+            delay(50);
           }
-          if (input_field == 0) {
-            edit_mode = false;
-          }
-        }
-        delay(50);
-      }  // EDITING loop
+          break;
+        default:
+          Serial.print("Case ");
+          Serial.print(input_field);
+          Serial.println(" not supported");
+          Serial.println("Which parameter would you like to edit?");
+          Serial.println("0. NONE, done editing, resume normal operations");
+          Serial.println("1. damper_threshold");
+          break;
+      }
+      if (input_field == 0) {
+        edit_mode = false;
+      }
+    }
+    delay(50);
+  }  // EDITING loop
   // restore default timeout outside of parameter editing mode
   Serial.setTimeout(1000L);
 }

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -197,8 +197,7 @@ float damper_velocity[NUM_CHANNELS], hammer_velocity[NUM_CHANNELS];
 
 int input_field = -1;
 float input_data;
-bool keep_reading = true;
-bool edit_mode = false;
+bool keep_editing = false;
 
 void edit_parameters() {
   // effectively "infinite" timeout (~ 1 month) when waiting for input
@@ -206,11 +205,11 @@ void edit_parameters() {
 
   Serial.setTimeout(2073600000L);
   Serial.println("Entered parameter editing mode.");
-  Serial.println("Which parameter would you like to edit?");
-  Serial.println("0. NONE, done editing, resume normal operations");
-  Serial.println("1. damper_threshold");
-  edit_mode = true;
-  while (edit_mode) {
+  keep_editing = true;
+  while (keep_editing) {
+    Serial.println("Which parameter would you like to edit?");
+    Serial.println("0. NONE, done editing, resume normal operations");
+    Serial.println("1. damper_threshold");
     if (Serial.available() > 0) {
       input_field = Serial.parseInt();
       switch (input_field) {
@@ -236,13 +235,10 @@ void edit_parameters() {
           Serial.print("Case ");
           Serial.print(input_field);
           Serial.println(" not supported");
-          Serial.println("Which parameter would you like to edit?");
-          Serial.println("0. NONE, done editing, resume normal operations");
-          Serial.println("1. damper_threshold");
           break;
       }
       if (input_field == 0) {
-        edit_mode = false;
+        keep_editing = false;
       }
     }
     delay(50);

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -237,6 +237,10 @@ void edit_parameters() {
 
   // restore default timeout outside of parameter editing mode
   Serial.setTimeout(1000L);
+
+  // re-run the set up with the changed values (may be unnecessary)
+  Serial.println("Setting up the board with your changes")
+  setup();
 }
 
 void loop() {

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -73,6 +73,13 @@ uint8_t Midi_Buffer[MIDI_BUFFER_SIZE];
 
 void setup(void) {
 
+  // Load the settings. Must be first in the setup() function.
+  Set.SetAllSettingValues();
+
+  partial_setup();
+}
+
+void partial_setup(void) {
   // Serial port setup.
   Serial.begin(9600);
   Serial.println(".");
@@ -92,9 +99,6 @@ void setup(void) {
   Serial.println("https://github.com/stem-piano");
   Serial.println(".");
   Serial.println(".");
-
-  // Load the settings. Must be first in the setup() function.
-  Set.SetAllSettingValues();
 
   // Notification messages.
   if (Set.debug_level >= DEBUG_INFO) {
@@ -240,7 +244,7 @@ void edit_parameters() {
 
   // re-run the set up with the changed values (may be unnecessary)
   Serial.println("Setting up the board with your changes")
-  setup();
+  partial_setup();
 }
 
 void loop() {

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -196,14 +196,13 @@ hammer_position_uncal[NUM_CHANNELS];
 float damper_velocity[NUM_CHANNELS], hammer_velocity[NUM_CHANNELS];
 
 int input_field = -1;
-float input_data;
 bool keep_editing = false;
 
 void edit_parameters() {
   // effectively "infinite" timeout (~ 1 month) when waiting for input
   // in this function (parameter editing mode)
-
   Serial.setTimeout(2073600000L);
+
   Serial.println("Entered parameter editing mode.");
   keep_editing = true;
   while (keep_editing) {
@@ -219,17 +218,9 @@ void edit_parameters() {
         case 1:
           Serial.print("Enter damper_threshold, currently ");
           Serial.println(Set.damper_threshold);
-          keep_reading = true;
-          while (keep_reading) {
-            if (Serial.available() > 0) {
-              input_data = Serial.parseFloat();
-              Set.damper_threshold = input_data;
-              Serial.print("Set damper_threshold = ");
-              Serial.println(Set.damper_threshold);
-              keep_reading = false;
-            }
-            delay(50);
-          }
+          Set.damper_threshold = Serial.parseFloat();
+          Serial.print("Set damper_threshold = ");
+          Serial.println(Set.damper_threshold);
           break;
         default:
           Serial.print("Case ");
@@ -241,8 +232,9 @@ void edit_parameters() {
         keep_editing = false;
       }
     }
-    delay(50);
-  }  // EDITING loop
+    delay(100);
+  }
+
   // restore default timeout outside of parameter editing mode
   Serial.setTimeout(1000L);
 }

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -168,7 +168,7 @@ void setup(void) {
   delay(1000);
   Tft.Clear();
 
-  Serial.println("Press 0 to enter parameter edit mode.");
+  Serial.println("Press 1 to enter parameter edit mode.");
 }
 
 // After startup, wait before sending anything to MIDI
@@ -200,11 +200,11 @@ float input_data;
 bool keep_reading = true;
 bool edit_mode = false;
 
-void loop() {
+void edit_parameters() {
+  // effectively "infinite" timeout (~ 1 month) when waiting for input
+  // in this function (parameter editing mode)
 
-  if (Serial.available() > 0) {
-    input_field = Serial.parseInt();
-    if (input_field == 0) {
+  Serial.setTimeout(2073600000L);
       Serial.println("Entered parameter editing mode.");
       Serial.println("Which parameter would you like to edit?");
       Serial.println("0. NONE, done editing, resume normal operations");
@@ -247,8 +247,19 @@ void loop() {
         }
         delay(50);
       }  // EDITING loop
-    }    // input_mode note EDITING
-  }      // no Serial.available
+  // restore default timeout outside of parameter editing mode
+  Serial.setTimeout(1000L);
+}
+
+void loop() {
+
+  if (Serial.available() > 0) {
+    input_field = Serial.parseInt(); // defaults to zero if times out
+    if (input_field == 1) {
+      edit_parameters();
+    }
+  }
+
   Tmg.WarnOnProcessingInterval();
   HStat.DisplayProcessingIntervalStart();
 

--- a/firmware/releases/ips2_hammer/ips2_hammer.ino
+++ b/firmware/releases/ips2_hammer/ips2_hammer.ino
@@ -168,6 +168,7 @@ void setup(void) {
   delay(1000);
   Tft.Clear();
 
+  Serial.println("Press 0 to enter parameter edit mode.");
 }
 
 // After startup, wait before sending anything to MIDI
@@ -194,8 +195,60 @@ float damper_position[NUM_CHANNELS], hammer_position[NUM_CHANNELS],
 hammer_position_uncal[NUM_CHANNELS];
 float damper_velocity[NUM_CHANNELS], hammer_velocity[NUM_CHANNELS];
 
+int input_field = -1;
+float input_data;
+bool keep_reading = true;
+bool edit_mode = false;
+
 void loop() {
 
+  if (Serial.available() > 0) {
+    input_field = Serial.parseInt();
+    if (input_field == 0) {
+      Serial.println("Entered parameter editing mode.");
+      Serial.println("Which parameter would you like to edit?");
+      Serial.println("0. NONE, done editing, resume normal operations");
+      Serial.println("1. damper_threshold");
+      edit_mode = true;
+      while (edit_mode) {
+        if (Serial.available() > 0) {
+          input_field = Serial.parseInt();
+          switch (input_field) {
+            case 0:
+              // taken care of later
+              break;
+            case 1:
+              Serial.print("Enter damper_threshold, currently ");
+              Serial.println(Set.damper_threshold);
+              keep_reading = true;
+              while (keep_reading) {
+                if (Serial.available() > 0) {
+                  input_data = Serial.parseFloat();
+                  Set.damper_threshold = input_data;
+                  Serial.print("Set damper_threshold = ");
+                  Serial.println(Set.damper_threshold);
+                  keep_reading = false;
+                }
+                delay(50);
+              }
+              break;
+            default:
+              Serial.print("Case ");
+              Serial.print(input_field);
+              Serial.println(" not supported");
+              Serial.println("Which parameter would you like to edit?");
+              Serial.println("0. NONE, done editing, resume normal operations");
+              Serial.println("1. damper_threshold");
+              break;
+          }
+          if (input_field == 0) {
+            edit_mode = false;
+          }
+        }
+        delay(50);
+      }  // EDITING loop
+    }    // input_mode note EDITING
+  }      // no Serial.available
   Tmg.WarnOnProcessingInterval();
   HStat.DisplayProcessingIntervalStart();
 


### PR DESCRIPTION
I've spent more time than I wanted to change various parameters in a  way suitable to my hardware, and today I said "enough", so I wrote this code for the `damper_threshold`. It would be very simple to add other parameters, and maybe doing the same for the damper board too (note to the casual reader, this is not a typo: the `damper_threshold` parameter is set in the hammer board).

In its current status this code has a bug: if one is not fast enough (typing is not fast enough, need to copy-paste), a zero is pushed rather than the value one wants to. Even with this bug, I find this code incredibly useful, and much faster than recompiling-and-redownloading the firmware for each and every change. If this bug is unacceptable, we can investigate it and fix it before merging (I didn't bother because I was eager to find the appropriate `damper_threshold`, which I then didn't find, but I digress)