### PR TITLE
reverse dampers

### DIFF
--- a/firmware/releases/ips2_damper/damper_settings.h
+++ b/firmware/releases/ips2_damper/damper_settings.h
@@ -31,6 +31,10 @@
 
 #define IP_STRING_LENGTH 128
 
+// uncomment the next line if the dampers sensors are under the keys
+// rather than above
+// #define REVERSE_DAMPERS
+
 class DamperSettings
 {
   

--- a/firmware/releases/ips2_damper/ips2_damper.ino
+++ b/firmware/releases/ips2_damper/ips2_damper.ino
@@ -237,6 +237,11 @@ void loop() {
         position_adc_counts[k] = 0;
         calibrated_floats[k] = 0.0;
       }
+#ifdef REVERSE_DAMPERS
+      else {
+        calibrated_floats[k] = 1 - calibrated_floats[k];
+      }
+#endif
     }
 
     B2B.SendDamperData(calibrated_floats);


### PR DESCRIPTION
With my piano and my sensors (damper sensors located under the keys) I had to reverse the logic otherwise the note off is triggered on key push rather than key release.
Unless one uncomment the `#define` added by this commit, no changes happen, but nice to be able to do it that way rather than having to type it too